### PR TITLE
Teach the Rabbit how to purge files from the cloudflare cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "hubot-scripts": "~2.5.16",
     "hubot-shipit": "~0.1.1",
     "hubot-slack": "~3.2.1",
-    "hubot-youtube": "~0.1.2"
+    "hubot-youtube": "~0.1.2",
+    "request": "^2.61.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/cloudflare.coffee
+++ b/scripts/cloudflare.coffee
@@ -1,0 +1,102 @@
+# Description
+#   Execute cloudflare related tasks using Hubot
+#
+# Dependencies:
+#   "request": "2.61.0"
+#
+# Configuration:
+#   CF_EMAIL
+#   CF_TOKEN
+#   CF_ZONE
+#
+# Commands:
+#   hubot cf purge <Path of file to purge...> - Purges a file from cloudflare cache
+#
+# Notes:
+#   Be sure that the CF_TOKEN has access to the domain provided in CF_ZONE
+#
+# Author:
+#   gamerlv
+#
+
+r = require 'request'
+CF_email = process.env.CF_EMAIL
+CF_token = process.env.CF_TOKEN
+CF_zone  = process.env.CF_ZONE.replace("www.", "")
+ 
+Array::chunk = (chunkSize) ->
+  array = this
+  [].concat.apply [], array.map((elem, i) ->
+    (if i % chunkSize then [] else [array.slice(i, i + chunkSize)])
+  )
+
+getZoneId = (domainName, callback) ->
+  options =
+    url: "https://api.cloudflare.com/client/v4/zones/"
+    headers:
+      "X-Auth-Key": CF_token
+      "X-Auth-Email": CF_email
+    qs:
+      name: CF_zone
+      status: "active"
+    json: true
+
+  r.get options, (err, resp, body) ->
+    if err
+      callback(err, "")
+      return
+    if !body.success
+      callback(body.errors.join(", "), "")
+      return
+
+    if body.result.length > 0
+      callback(null, body.result[0].id)
+    else
+      callback("Not enough results; " + body.messages.join(", "), "")
+  
+
+module.exports = (robot) ->
+  # Match domain paths: ((\/[-\\w~,;\\./?%&+#=]*)\\s*)*
+  robot.respond "/cf purge (.*)/i", (msg) ->
+    files = msg.match[1].split(" ")
+    # Make sure there are no empty strings
+    files = files.filter (path, index, orgArr) ->
+      !( path.trim() == "" or !/(\/[-\w~,;\.\/?%&+=]*)/i.test(path) )
+
+    # CF needs files to be with the FQDN
+    for path,index in files
+      if path.indexOf "http" != 0
+        files[index] = "http://" + CF_zone + path
+    # console.log(msg.match, files)
+    files = files.chunk(30) # We may only send 30 files per request to cloudflare
+    
+    getZoneId CF_zone, (err, zoneID) ->
+      if err
+        msg.reply "Error while retriving zone: " + err
+        return
+
+      for filess in files
+        options =
+          url: "https://api.cloudflare.com/client/v4/zones/" + zoneID + "/purge_cache"
+          headers: 
+            "X-Auth-Key": CF_token
+            "X-Auth-Email": CF_email
+          json: true
+          body: 
+            "files": filess
+
+        r.del options, (err, resp, body) ->
+          if err
+            msg.reply "Can't do that now: " + err
+          else
+            if body.success
+              msg.send "cloudflare cache purged of " + filess.join(", ")
+            else
+              errorStr = ""
+              body.errors.map (error) ->
+                errorStr += error.code + ": " + error.message + ","
+                return
+
+              msg.reply "Purge failed; " + errorStr
+        
+

--- a/scripts/cloudflare.coffee
+++ b/scripts/cloudflare.coffee
@@ -63,6 +63,10 @@ module.exports = (robot) ->
     files = files.filter (path, index, orgArr) ->
       !( path.trim() == "" or !/(\/[-\w~,;\.\/?%&+=]*)/i.test(path) )
 
+    if files.length < 1
+      msg.reply "Could you tell me which files to purge? Usage: `cf purge </path> (/paths...)`"
+      return
+
     # CF needs files to be with the FQDN
     for path,index in files
       if path.indexOf "http" != 0

--- a/scripts/cloudflare.coffee
+++ b/scripts/cloudflare.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
         msg.reply "Error while retriving zone: " + err
         return
 
-      for filess in files
+      for files_chunk in files
         options =
           url: "https://api.cloudflare.com/client/v4/zones/" + zoneID + "/purge_cache"
           headers: 
@@ -87,14 +87,14 @@ module.exports = (robot) ->
             "X-Auth-Email": CF_email
           json: true
           body: 
-            "files": filess
+            "files": files_chunk
 
         r.del options, (err, resp, body) ->
           if err
             msg.reply "Can't do that now: " + err
           else
             if body.success
-              msg.send "cloudflare cache purged of " + filess.join(", ")
+              msg.send "cloudflare cache purged of " + files_chunk.join(", ")
             else
               errorStr = ""
               body.errors.map (error) ->


### PR DESCRIPTION
Add the command `cf purge <files...>` to the bot. This will purge the specified set of files from the cloudflare cache. 

Currently only does one domain because I didn't want to spend too much more time, If more than one domain is needed (e.g. beta subdomain) this could be done at a later time.

Requires a API key that has access to the domain given in `CF_ZONE` variable. The key for a account can be found here:  https://www.cloudflare.com/a/account/my-account

It's my first coffeescript thing I have done, please excuses the very verbose / messy file.